### PR TITLE
Update xatSocket.php

### DIFF
--- a/classes/xatSocket.php
+++ b/classes/xatSocket.php
@@ -107,7 +107,7 @@ class Socket
         // Removing < />
         $string = trim($string);
 
-        if (($string[0] != '<') or (substr($string, -2) != '/>')) {
+        if (($string[0] != '<') || (substr($string, -2) != '/>')) {
             throw new Exception('Corrupted packets.');
         }
         


### PR DESCRIPTION
PHP has two sets of logical operators: & / ||, and and / or. The difference between the sets is precedence. Because and / or have a lower precedence than almost any other operator, using them instead of && / || may not have the result you expect.
