### PR TITLE
Fix: Socket::read() not returning a packet when $force is true

### DIFF
--- a/classes/xatSocket.php
+++ b/classes/xatSocket.php
@@ -50,14 +50,16 @@ class Socket
             socket_set_block($this->socket);
         }
 
-        $packet = socket_read($this->socket, 1460);
+        do {
+            $packet = socket_read($this->socket, 1460);
 
-        if ($packet === false && (socket_last_error($this->socket) !== 0) && (socket_last_error($this->socket) !== 11)) {
-            $this->disconnect();
-            return false;
-        }
+            if ($packet === false && (socket_last_error($this->socket) !== 0) && (socket_last_error($this->socket) !== 11)) {
+                $this->disconnect();
+                return false;
+            }
 
-        $this->buffer .= $packet;
+            $this->buffer .= $packet;
+        } while($force && strpos($this->buffer, chr(0x00)) === false);
 
         if ($force === true) {
             socket_set_nonblock($this->socket);


### PR DESCRIPTION
In certain cases, Socket::read() may not return a packet, even though
$force is set to true.

This happens when packets are relatively large (typically > 1500 bytes,
headers included). Xat's server's IP stack fragments the packet in two
or more packets.

If we're lucky enough, our kernel will already have reassembled the
fragmented packets when we're calling read(). Even though this is what
happens most of the time, we may call read() between two packets.
The script will therefore read the first parts of a fragmented packet.

The workaround is to wait for the socket's buffer to have a NULL byte
(which is used to separate packets in xat's protocol)

(This time with strpos instead of substr)
